### PR TITLE
Shared TTS daemon with per-workspace identity

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,10 +100,42 @@ priority = 20
 The backlog is capped at 32 utterances; past that, new audio is dropped rather
 than queued behind speech that will be stale by the time it plays.
 
+## Per-workspace identity
+
+With several agents running, the useful question is not "what did it say" but
+"which one said it". The daemon answers that two ways at once.
+
+**A spoken label.** Each message is prefixed with the workspace directory name,
+so `notify("Tests passed")` from `~/projects/spade` is heard as *"spade. Tests
+passed."* Disable with `prefix = false`.
+
+**A distinct voice per workspace.** The server reads the client's advertised
+root via MCP `roots`, and assigns a voice from a pool of nine on first contact.
+Assignments persist in `~/.config/tts-mcp-server/assignments.json` and are keyed
+on the root path, so they survive daemon restarts.
+
+Pin one explicitly if you'd rather not take what you're given:
+
+```toml
+[voices]
+spade = "bm_daniel"
+```
+
+**Why the label does the heavy lifting.** The nine pooled voices were picked by
+rating every cloned candidate 1–10 and then solving for the subset with maximum
+minimum pairwise separation (speaker-embedding cosine). Even so, the best
+possible nine still contain a pair at 0.86 cosine — Chatterbox pulls everything
+it clones toward its own character, compressing the whole set into 0.74–0.90.
+Voice alone reliably distinguishes four or five workspaces, not nine. The label
+is what actually scales; the voice reinforces it.
+
+Past nine workspaces the pool wraps deterministically, and two projects share a
+voice. Only the label tells them apart at that point.
+
 ## Voices
 
-Chatterbox has no voice presets. It clones from a reference clip, which is what
-lifts the per-workspace-voice ceiling — but it means you supply the clips.
+Chatterbox has no voice presets. It clones from a reference clip — which is what
+lifts the ceiling — but it means you supply the clips.
 
 Reference clips must be **longer than 5 seconds**. The easiest source that
 involves no one's actual voice is to synthesize them from Kokoro's presets:

--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
 # tts-mcp-server
 
 Local text-to-speech for Claude Code via [MCP](https://modelcontextprotocol.io/).
-Runs [Kokoro-82M](https://huggingface.co/mlx-community/Kokoro-82M-bf16) on Apple
-Silicon through [MLX-audio](https://github.com/ml-explore/mlx-audio), giving Claude
-the ability to speak task notifications and arbitrary text aloud.
+Runs [Chatterbox Turbo](https://huggingface.co/ResembleAI/chatterbox-turbo) on
+Apple Silicon through [MLX-audio](https://github.com/Blaizzy/mlx-audio), so Claude
+can speak notifications and narration aloud — with a distinct voice per workspace
+when several agents are running at once.
 
-**Requirements:** macOS on Apple Silicon (M1+), Python 3.12+.
+**Requirements:** macOS on Apple Silicon, Python 3.12+.
 
 ## Setup
 
@@ -13,108 +14,170 @@ the ability to speak task notifications and arbitrary text aloud.
 cd ~/projects/tts-mcp-server
 uv venv && uv pip install -e .
 
-# Pre-download the TTS model (~200 MB, one-time):
-uv run tts-mcp-init
+# Pre-download the model (~3 GB) and write a default config:
+uv run tts-mcp-server init
 ```
 
-Register with Claude Code (user-wide, available in all projects):
+### Shared daemon (recommended)
+
+One process serves every Claude Code session. This is the mode worth running if
+you keep more than one or two sessions open.
+
+```bash
+sed "s|__VENV__|$PWD/.venv|g" launchd/com.tts-mcp-server.plist \
+  > ~/Library/LaunchAgents/com.tts-mcp-server.plist
+launchctl load ~/Library/LaunchAgents/com.tts-mcp-server.plist
+
+claude mcp add --transport http --scope user tts http://127.0.0.1:8765/mcp
+```
+
+Why bother: with per-session servers, each session loads its own copy of the
+model and owns its own speaker, so two agents talking at once produce overlapping
+audio you can't parse. One daemon means one model in memory, one warmup, and a
+single playback queue — so an urgent `permission` message in one workspace
+preempts `narrate` in another instead of racing it.
+
+The daemon warms the model at load, so the ~20 s startup is paid once at login
+rather than charged to whichever agent speaks first.
+
+### Per-session stdio (fallback)
 
 ```bash
 claude mcp add --transport stdio --scope user tts -- \
   /path/to/tts-mcp-server/.venv/bin/tts-mcp-server
 ```
 
-Verify:
+Simpler, no lifecycle to manage, and the server lives exactly as long as its
+session. But each session pays its own ~3 GB and its own warmup, and audio from
+concurrent sessions overlaps.
 
-```bash
-claude mcp list   # should show tts: ✓ Connected
-```
+Verify either mode with `claude mcp list`.
 
 ## Tools
 
-### `notify(message)`
+### `notify(message, speed?, channel?)`
 
-Quick task-completion alert. Speaks at 1.2x speed with the default voice
-(`af_heart`). Designed for short messages like "Build finished" or "Tests
-passed".
+Short task-completion alert. Uses the configured voice.
 
-### `speak(text, voice?, speed?)`
+### `speak(text, ref_audio?, speed?, channel?)`
 
-Full TTS with voice and speed control.
+Longer narration, optionally in a cloned voice.
 
-| Parameter | Default      | Range / Options       |
-| --------- | ------------ | --------------------- |
-| `text`    | _(required)_ | Any string            |
-| `voice`   | `af_heart`   | See [voices](#voices) |
-| `speed`   | `1.2`        | 0.5 -- 2.0            |
+| Parameter   | Default      | Notes                                    |
+| ----------- | ------------ | ---------------------------------------- |
+| `text`      | _(required)_ | Any string                               |
+| `ref_audio` | built-in     | Path to a WAV to clone; **must be >5 s** |
+| `speed`     | `1.2`        | 0.5 – 2.0, applied at playback           |
+| `channel`   | _(none)_     | See [channels](#channels)                |
+
+### `interrupt()`
+
+Stops what's playing and discards the backlog. Takes no arguments. Useful when
+queued narration has been overtaken by events.
+
+## Channels
+
+Named profiles for speed and priority, so urgent speech jumps the queue.
+Defaults:
+
+| Channel      | Speed | Priority    |
+| ------------ | ----- | ----------- |
+| `permission` | 1.0   | 1 (highest) |
+| `question`   | 1.0   | 2           |
+| `notify`     | 1.2   | 10          |
+| `narrate`    | 1.3   | 15          |
+
+Override in `~/.config/tts-mcp-server/channels.toml`:
+
+```toml
+# ref_audio = "/Users/you/.config/tts-mcp-server/voices/mine.wav"
+
+[narrate]
+speed = 1.4
+priority = 20
+```
+
+The backlog is capped at 32 utterances; past that, new audio is dropped rather
+than queued behind speech that will be stale by the time it plays.
 
 ## Voices
 
-Kokoro ships 54 presets. A useful subset:
+Chatterbox has no voice presets. It clones from a reference clip, which is what
+lifts the per-workspace-voice ceiling — but it means you supply the clips.
 
-| ID          | Description               |
-| ----------- | ------------------------- |
-| `af_heart`  | American female (default) |
-| `af_bella`  | American female           |
-| `af_nova`   | American female           |
-| `am_adam`   | American male             |
-| `am_echo`   | American male             |
-| `bf_emma`   | British female            |
-| `bm_george` | British male              |
+Reference clips must be **longer than 5 seconds**. The easiest source that
+involves no one's actual voice is to synthesize them from Kokoro's presets:
 
-Full list: prefix `af_` / `am_` (American), `bf_` / `bm_` (British),
-`jf_` / `jm_` (Japanese), `zf_` / `zm_` (Chinese).
+```python
+import soundfile as sf, numpy as np, mlx.core as mx
+from mlx_audio.tts.utils import load_model
+
+k = load_model("mlx-community/Kokoro-82M-bf16")
+text = "A sentence long enough to run past the five second minimum, plus another to be safe."
+chunks = [r.audio for r in k.generate(text=text, voice="am_adam", speed=1.0, lang_code="a")]
+audio = mx.concatenate(chunks) if len(chunks) > 1 else chunks[0]
+mx.eval(audio)
+sf.write("voices/am_adam.wav", np.asarray(audio), 24000)
+```
+
+Encoded conditionals are cached per clip, so a cloned utterance costs ~300 ms
+rather than the ~950 ms it takes to re-encode the reference every call.
+
+**On cloning real voices:** a reference clip is impersonation capability, whoever
+it came from and whatever it was made for. Your own voice and synthesized clips
+are unproblematic; a third party's needs their agreement. Note also that upstream
+Chatterbox watermarks its output via `resemble-perth`, and the MLX port does not —
+audio from this server carries no watermark.
+
+## Performance
+
+Measured on an M5 Max, short phrase ("Tests passed."), best of three warm runs:
+
+| Model             | Latency | RTF   | Peak RSS |
+| ----------------- | ------- | ----- | -------- |
+| Kokoro-82M        | 37 ms   | 0.025 | 0.78 GB  |
+| Chatterbox base   | 660 ms  | 0.412 | 3.64 GB  |
+| Turbo fp16        | 330 ms  | 0.235 | 2.95 GB  |
+| **Turbo 8-bit**   | 190 ms  | 0.164 | 2.98 GB  |
+| Turbo 4-bit       | 200 ms  | 0.158 | 2.98 GB  |
+
+8-bit is the default: it ties 4-bit on speed and memory, so there's nothing to
+gain from quantizing further. RTF 0.164 means synthesis runs ~6× faster than
+playback, so the speaker is the bottleneck, not the model — adding more agents
+doesn't make synthesis the constraint.
 
 ## Architecture
 
 ```
-Claude Code  ──stdio──>  FastMCP server  ──>  MLX-audio/Kokoro  ──>  afplay
+N × Claude Code  ──http──>  one daemon  ──>  Chatterbox Turbo  ──>  afplay
+                                 │
+                        global priority queue
 ```
 
-- **Lazy loading:** The model, spacy G2P pipeline, and Metal shaders all
-  initialize on the first tool call (~6 s). This keeps the MCP handshake
-  instant so health checks pass. Subsequent calls run in ~0.1 s.
-- **No persistent daemon:** Claude Code spawns the server on session start and
-  kills it on exit. No LaunchAgent needed.
-- **Temp files:** Audio is written to a temp WAV, played with `afplay`, then
-  deleted. No disk accumulation.
-
-## Performance (M2 Max)
-
-| Metric                 | First call             | Subsequent |
-| ---------------------- | ---------------------- | ---------- |
-| Latency (short phrase) | ~6 s                   | ~0.1 s     |
-| Memory                 | ~420 MB                | ~420 MB    |
-| CPU                    | < 5% (GPU-accelerated) | < 5%       |
+- **Serialized synthesis.** MLX's Metal command buffer aborts the process if two
+  threads evaluate concurrently, so all inference runs on a single dedicated
+  thread. Costs nothing at ~190 ms per utterance.
+- **Speed at playback.** Chatterbox ignores a speed argument, so rate is applied
+  via `afplay -r`. Changing speed doesn't re-run inference.
+- **Temp files.** Audio is written to a temp WAV, played, then deleted.
 
 ## Troubleshooting
 
-**Server shows `✗ Failed to connect`:** The model is loading during the health
-check. This was fixed by deferring model load to first tool call. If you still
-see this, ensure `main()` calls `mcp.run()` immediately (before any model
-loading).
+**Daemon not reachable:** `launchctl list | grep tts`, then check
+`/tmp/tts-mcp-server.err`. Claude Code reconnects automatically once it's back;
+only the utterance in flight is lost.
 
-**First call is slow (~6 s):** Expected. Spacy G2P pipeline and Metal shader
-compilation happen once per server lifetime. After that, calls are sub-200 ms.
+**Must be a LaunchAgent, not a LaunchDaemon.** LaunchDaemons run outside your GUI
+session and can't reach the audio device, so `afplay` fails silently.
 
-**First call hangs indefinitely:** The spacy `en_core_web_sm` model is missing.
-Misaki's G2P calls `spacy.cli.download()` at runtime, which shells out to `pip`
--- but uv-managed venvs don't have `pip`, so it hangs forever. This model is
-declared as a dependency in `pyproject.toml`, so `uv pip install -e .` should
-handle it. If you somehow end up without it, reinstall.
+**`Audio prompt must be longer than 5 seconds`:** your `ref_audio` clip is too
+short. The server checks this up front.
 
-**`afplay` not found:** You're not on macOS. Replace the `afplay` call in
-`_play()` with your platform's audio player (e.g., `paplay` on Linux, `sox`
-cross-platform).
+**First call slow:** the model is loading (~20 s). The daemon warms at startup;
+stdio mode loads lazily on first call.
 
-**Model download fails:** Pre-download with the init script, or manually via
-`huggingface-cli`:
-
-```bash
-uv run tts-mcp-init
-# or:
-.venv/bin/huggingface-cli download mlx-community/Kokoro-82M-bf16
-```
+**`afplay` not found:** you're not on macOS. Replace the `afplay` call in
+`PlaybackQueue._play()` with your platform's player.
 
 ## License
 

--- a/launchd/com.tts-mcp-server.plist
+++ b/launchd/com.tts-mcp-server.plist
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  LaunchAgent for the shared TTS daemon.
+
+  Install (substitutes the absolute path, which launchd requires):
+
+    sed "s|__VENV__|$PWD/.venv|g" launchd/com.tts-mcp-server.plist \
+      > ~/Library/LaunchAgents/com.tts-mcp-server.plist
+    launchctl load ~/Library/LaunchAgents/com.tts-mcp-server.plist
+
+  A LaunchAgent (not a LaunchDaemon) is required: LaunchDaemons run outside the
+  user's GUI session and cannot reach the audio device, so afplay would fail.
+-->
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.tts-mcp-server</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>__VENV__/bin/tts-mcp-server</string>
+        <string>--transport</string>
+        <string>http</string>
+        <string>--host</string>
+        <string>127.0.0.1</string>
+        <string>--port</string>
+        <string>8765</string>
+    </array>
+
+    <key>RunAtLoad</key>
+    <true/>
+
+    <!-- Restart if the daemon dies. One process now serves every session, so a
+         crash silences the whole fleet until it comes back. Claude Code
+         reconnects on its next tool call; only the utterance in flight is lost. -->
+    <key>KeepAlive</key>
+    <true/>
+
+    <!-- Don't respawn faster than this if it crashes on startup. -->
+    <key>ThrottleInterval</key>
+    <integer>10</integer>
+
+    <key>StandardOutPath</key>
+    <string>/tmp/tts-mcp-server.log</string>
+    <key>StandardErrorPath</key>
+    <string>/tmp/tts-mcp-server.err</string>
+
+    <key>ProcessType</key>
+    <string>Interactive</string>
+</dict>
+</plist>

--- a/tts_server.py
+++ b/tts_server.py
@@ -16,6 +16,7 @@ import logging
 import pathlib
 import signal
 import tempfile
+import time
 import tomllib
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
@@ -54,6 +55,14 @@ MIN_REF_SECONDS = 5.0
 MAX_BACKLOG = 32
 
 CHANNELS_CONFIG = pathlib.Path.home() / ".config" / "tts-mcp-server" / "channels.toml"
+
+# Shared-daemon defaults. One process serving every session means one model in
+# memory instead of one per session, one warmup instead of N, and — the point —
+# a single playback queue, so an urgent channel in one workspace preempts
+# narration in another. Loopback only: an open port here lets any local process
+# make the machine talk.
+DEFAULT_HOST = "127.0.0.1"
+DEFAULT_PORT = 8765
 
 
 # ---------------------------------------------------------------------------
@@ -143,6 +152,7 @@ def _resolve(
 
 _ref_audio: str | None = None
 _channels: dict[str, Channel] = {}
+_warm_on_start: bool = False
 
 
 # ---------------------------------------------------------------------------
@@ -268,11 +278,30 @@ async def lifespan(_server: FastMCP) -> AsyncIterator[dict]:
     _ref_audio, _channels = load_config()
     _playback = PlaybackQueue()
     _playback.start()
+    # Warm the model off the critical path. Loading takes ~20 s, which a
+    # long-lived daemon should absorb at login rather than charging to whoever
+    # sends the first notification. The transport is already listening, so the
+    # handshake stays instant either way.
+    warm = asyncio.create_task(_warmup()) if _warm_on_start else None
     try:
         yield {}
     finally:
+        if warm is not None:
+            warm.cancel()
         await _playback.stop()
         _playback = None
+
+
+async def _warmup() -> None:
+    """Load the model in the synthesis thread, logging rather than raising."""
+    try:
+        t0 = time.monotonic()
+        await asyncio.get_running_loop().run_in_executor(_synthesis, load_model)
+        logger.info("Warmup finished in %.1fs.", time.monotonic() - t0)
+    except asyncio.CancelledError:
+        raise
+    except Exception:
+        logger.exception("Warmup failed; first call will pay the load cost")
 
 
 mcp = FastMCP("TTS Notification Server", lifespan=lifespan)
@@ -430,11 +459,63 @@ def _validate_speed(speed: float) -> None:
         raise ValueError(f"Speed must be {MIN_SPEED}–{MAX_SPEED}, got {speed}")
 
 
-def main():
-    logger.info("Starting TTS MCP server ...")
-    # Start the MCP transport immediately so the handshake succeeds,
-    # then warm up the model lazily on first tool call.
-    mcp.run(transport="stdio")
+def main(argv: list[str] | None = None) -> None:
+    """Run the server. Argument parsing lives here so the console script sees it."""
+    global _warm_on_start
+    args = _parse_args(argv)
+
+    if args.command == "init":
+        logger.info("Preloading model for faster first response...")
+        init()
+        return
+
+    # Warm eagerly when we're the shared daemon, lazily when we're a per-session
+    # stdio child that may never be asked to speak at all.
+    _warm_on_start = args.warm if args.warm is not None else args.transport == "http"
+
+    if args.transport == "http":
+        logger.info("Starting shared TTS daemon on %s:%d ...", args.host, args.port)
+        mcp.run(transport="http", host=args.host, port=args.port)
+    else:
+        logger.info("Starting TTS MCP server (stdio) ...")
+        mcp.run(transport="stdio")
+
+
+def _parse_args(argv: list[str] | None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        prog="tts-mcp-server",
+        description="TTS MCP server for Claude Code — Chatterbox Turbo on Apple Silicon.",
+        epilog="Run without arguments for a per-session stdio server.",
+    )
+    parser.add_argument(
+        "command",
+        nargs="?",
+        choices=["init"],
+        default=None,
+        help="'init' to pre-download the TTS model and write a default config.",
+    )
+    parser.add_argument(
+        "--transport",
+        choices=["stdio", "http"],
+        default="stdio",
+        help="'http' runs one shared daemon for every session (default: stdio).",
+    )
+    parser.add_argument("--host", default=DEFAULT_HOST, help="HTTP bind address.")
+    parser.add_argument(
+        "--port", type=int, default=DEFAULT_PORT, help="HTTP port to listen on."
+    )
+    warm = parser.add_mutually_exclusive_group()
+    warm.add_argument(
+        "--warm",
+        dest="warm",
+        action="store_true",
+        default=None,
+        help="Load the model at startup instead of on first call.",
+    )
+    warm.add_argument(
+        "--no-warm", dest="warm", action="store_false", help="Always load lazily."
+    )
+    return parser.parse_args(argv)
 
 
 def write_default_config(path: pathlib.Path = CHANNELS_CONFIG) -> bool:
@@ -464,21 +545,4 @@ def init():
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(
-        description="TTS MCP server for Claude Code — Kokoro-82M on Apple Silicon.",
-        epilog="Run without arguments to start the MCP server.",
-    )
-    parser.add_argument(
-        "command",
-        nargs="?",
-        choices=["init"],
-        default=None,
-        help="'init' to pre-download the TTS model (~200 MB).",
-    )
-    args = parser.parse_args()
-
-    if args.command == "init":
-        logger.info("Preloading model for faster first response...")
-        init()
-    else:
-        main()
+    main()

--- a/tts_server.py
+++ b/tts_server.py
@@ -12,18 +12,20 @@ import concurrent.futures
 import dataclasses
 import functools
 import itertools
+import json
 import logging
 import pathlib
 import signal
 import tempfile
 import time
 import tomllib
+import urllib.parse
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 
 import mlx.core as mx
 import soundfile as sf
-from fastmcp import FastMCP
+from fastmcp import Context, FastMCP
 from mlx.nn.layers import Module
 from mlx_audio.tts.utils import load_model as mlx_load_model
 from rich.logging import RichHandler
@@ -108,8 +110,13 @@ def load_config(
         except ValueError as e:
             logger.warning("%s — falling back to built-in voice.", e)
             ref_audio = None
+
+    global _prefix_enabled, _voice_overrides
+    _prefix_enabled = bool(raw.get("prefix", True))
+    _voice_overrides = dict(raw.get("voices", {}))
+
     for name, overrides in raw.items():
-        if not isinstance(overrides, dict):
+        if name == "voices" or not isinstance(overrides, dict):
             continue
         base = DEFAULT_CHANNELS.get(name)
         channels[name] = Channel(
@@ -153,6 +160,126 @@ def _resolve(
 _ref_audio: str | None = None
 _channels: dict[str, Channel] = {}
 _warm_on_start: bool = False
+
+
+# ---------------------------------------------------------------------------
+# Identity — which workspace is speaking
+# ---------------------------------------------------------------------------
+
+VOICES_DIR = pathlib.Path.home() / ".config" / "tts-mcp-server" / "voices" / "refs"
+ASSIGNMENTS = pathlib.Path.home() / ".config" / "tts-mcp-server" / "assignments.json"
+
+# Auditioned set: every voice rated 8+, then the exact maximin subset by
+# speaker-embedding cosine. Ordered best-rated first, which is also assignment
+# order, so the first workspace seen gets the best voice.
+#
+# Nine voices is the ceiling and it is a soft one — the most separated nine of
+# any selection still contain a pair at 0.86 cosine, because Chatterbox pulls
+# everything it clones toward its own character. Voice alone reliably carries
+# maybe four or five workspaces, which is why the spoken label does the real
+# work and the voice reinforces it.
+VOICE_POOL = (
+    "af_heart",
+    "af_jessica",
+    "af_sarah",
+    "am_liam",
+    "bf_isabella",
+    "am_fenrir",
+    "am_puck",
+    "bf_alice",
+    "bm_daniel",
+)
+
+
+class VoiceRegistry:
+    """Assigns a stable voice per workspace, surviving daemon restarts.
+
+    Keyed on the workspace root rather than the MCP session id: a session id
+    rotates whenever the client reconnects, which would reshuffle every voice
+    the first time the daemon bounced.
+    """
+
+    def __init__(self, path: pathlib.Path = ASSIGNMENTS) -> None:
+        self._path = path
+        self._map: dict[str, str] = {}
+        try:
+            self._map = json.loads(path.read_text())
+        except FileNotFoundError:
+            pass
+        except (OSError, ValueError):
+            logger.warning("Could not read %s — starting fresh.", path)
+
+    def voice(self, root: str) -> str:
+        """Preset assigned to this workspace, allocating one on first sight."""
+        if root not in self._map:
+            used = set(self._map.values())
+            free = [v for v in VOICE_POOL if v not in used]
+            # Past nine workspaces the pool wraps. Deterministic so the
+            # assignment is at least stable, but two roots now share a voice
+            # and only the spoken label tells them apart.
+            self._map[root] = (
+                free[0] if free else VOICE_POOL[len(self._map) % len(VOICE_POOL)]
+            )
+            logger.info("Assigned voice %s to %s", self._map[root], root)
+            self._save()
+        return self._map[root]
+
+    def _save(self) -> None:
+        try:
+            self._path.parent.mkdir(parents=True, exist_ok=True)
+            self._path.write_text(json.dumps(self._map, indent=2, sort_keys=True))
+        except OSError:
+            logger.warning("Could not persist assignments to %s", self._path)
+
+
+_registry = VoiceRegistry()
+_voice_overrides: dict[str, str] = {}
+_prefix_enabled: bool = True
+
+
+async def identity(ctx: Context) -> tuple[str | None, str]:
+    """Resolve the caller's workspace into a voice and a spoken label.
+
+    :returns: (ref_audio path or None, label — empty when unidentifiable)
+    """
+    root = await workspace_root(ctx)
+    if root is None:
+        return _ref_audio, ""
+    label = pathlib.PurePath(root).name or "workspace"
+    preset = _voice_overrides.get(label) or _registry.voice(root)
+    clip = VOICES_DIR / f"{preset}.wav"
+    if not clip.is_file():
+        logger.warning("Voice clip %s missing — using configured default.", clip)
+        return _ref_audio, label
+    return str(clip), label
+
+
+async def workspace_root(ctx: Context) -> str | None:
+    """Filesystem path the client advertises as its root, if it advertises one."""
+    try:
+        roots = await ctx.list_roots()
+    except Exception as e:  # noqa: BLE001 - identity is best-effort
+        # Clients need not support roots, and a transport hiccup here should
+        # cost the label, not the notification.
+        logger.debug("No workspace root available: %s", e)
+        return None
+    if not roots:
+        return None
+    uri = str(roots[0].uri)
+    if not uri.startswith("file://"):
+        return uri or None
+    return urllib.parse.unquote(urllib.parse.urlparse(uri).path) or None
+
+
+def announce(label: str, text: str) -> str:
+    """Prepend the workspace label so the listener knows who is talking.
+
+    A period rather than a dash: the engine reads it as a pause, where a dash
+    is either swallowed or spoken.
+    """
+    if not label or not _prefix_enabled:
+        return text
+    return f"{label}. {text}"
 
 
 # ---------------------------------------------------------------------------
@@ -310,6 +437,7 @@ mcp = FastMCP("TTS Notification Server", lifespan=lifespan)
 @mcp.tool()
 async def notify(
     message: str,
+    ctx: Context,
     speed: float | None = None,
     channel: str | None = None,
 ) -> str:
@@ -322,15 +450,17 @@ async def notify(
     playback = _require_playback()
     speed_, priority = _resolve(_channels, channel, speed)
     _validate_speed(speed_)
-    audio = await synthesize(message, ref_audio=_ref_audio)
+    ref, label = await identity(ctx)
+    audio = await synthesize(announce(label, message), ref_audio=ref)
     if not playback.enqueue(audio, priority=priority, speed=speed_):
         return f"Dropped (backlog full): {message}"
-    return f"Notified: {message}"
+    return f"Notified{f' as {label}' if label else ''}: {message}"
 
 
 @mcp.tool()
 async def speak(
     text: str,
+    ctx: Context,
     ref_audio: str | None = None,
     speed: float | None = None,
     channel: str | None = None,
@@ -338,21 +468,24 @@ async def speak(
     """Generate and play speech, optionally cloning a reference voice.
 
     :param text: Text to speak.
-    :param ref_audio: Path to a WAV clip to clone (overrides instance default).
+    :param ref_audio: Path to a WAV clip to clone (overrides the workspace voice).
     :param speed: Playback speed multiplier, 0.5–2.0.
     :param channel: Named channel for speed/priority defaults.
     """
     playback = _require_playback()
-    ref = ref_audio if ref_audio is not None else _ref_audio
-    if ref is not None:
-        _validate_ref_audio(ref)
+    if ref_audio is not None:
+        _validate_ref_audio(ref_audio)
+        ref, label = ref_audio, ""
+    else:
+        ref, label = await identity(ctx)
     speed_, priority = _resolve(_channels, channel, speed)
     _validate_speed(speed_)
-    audio = await synthesize(text, ref_audio=ref)
+    audio = await synthesize(announce(label, text), ref_audio=ref)
     if not playback.enqueue(audio, priority=priority, speed=speed_):
         return f"Dropped (backlog full): {len(text)} chars"
     dur = len(audio) / SAMPLE_RATE / speed_
-    return f"Spoke {len(text)} chars in {dur:.1f}s (voice={ref or 'built-in'}, speed={speed_}x)"
+    who = label or pathlib.PurePath(ref).stem if ref else "built-in"
+    return f"Spoke {len(text)} chars in {dur:.1f}s (voice={who}, speed={speed_}x)"
 
 
 @mcp.tool()
@@ -527,8 +660,19 @@ def write_default_config(path: pathlib.Path = CHANNELS_CONFIG) -> bool:
         logger.info("Config already exists at %s — skipping.", path)
         return False
     lines = [
-        "# Path to a WAV clip to clone. Omit to use Chatterbox's built-in voice.",
-        '# ref_audio = "/Users/you/.config/tts-mcp-server/voices/mine.wav"',
+        "# Speak the workspace name before each message, so you can tell which",
+        "# agent is talking. Voice alone does not reliably carry more than a few.",
+        "prefix = true",
+        "",
+        "# Fallback clip when the workspace can't be identified. Omit for the",
+        "# built-in voice.",
+        '# ref_audio = "/Users/you/.config/tts-mcp-server/voices/refs/af_heart.wav"',
+        "",
+        "# Pin a workspace to a voice. Keys are directory names; values are",
+        "# presets under voices/refs/. Unpinned workspaces are assigned",
+        "# automatically on first contact and remembered in assignments.json.",
+        "# [voices]",
+        '# spade = "af_heart"',
         "",
     ]
     for name, ch in DEFAULT_CHANNELS.items():


### PR DESCRIPTION
Makes one daemon serve every Claude Code session, and makes each session
identifiable by ear.

## Why

Per-session stdio servers each load their own model and own their own speaker.
Nine sessions meant nine copies of a 3 GB model and, worse, nine independent
playback queues — so two agents speaking at once overlapped into noise. The
playback queue added earlier serializes *within* a process, which turned out to
be the wrong scope entirely.

## What changed

**Shared daemon over HTTP.** MCP over HTTP is the whole mechanism — no shim, no
IPC protocol. One process, one model, one warmup, and critically one *global*
priority queue, so an urgent `permission` in one workspace preempts `narrate` in
another instead of racing it. stdio remains the default and is unchanged.

**Per-workspace identity.** `notify("Tests passed")` from `~/projects/spade` is
heard as *"spade. Tests passed."*, in a voice reserved for that workspace.
Assignments key on the client's advertised MCP root, persist across restarts,
and can be pinned in `[voices]`.

**LaunchAgent** template with `KeepAlive`. An Agent rather than a Daemon
deliberately: LaunchDaemons run outside the GUI session and cannot reach the
audio device, so `afplay` fails silently.

**Fixed a latent bug:** argument parsing sat under `if __name__ == "__main__"`,
so the installed console script bypassed it and no flag was reachable.

## Measurements behind the decisions

Taken against real Claude Code clients rather than assumed:

- **`session_id` rotates on reconnect; the workspace root does not.** Keying
  voices on session id would have reshuffled every voice the first time the
  daemon bounced. Root it is.
- **Claude Code reconnects on its own** after the daemon dies — only the call in
  flight is lost. That is what makes direct HTTP viable and a reconnecting shim
  unnecessary.
- **Audio genuinely serializes across sessions.** Polled `afplay` children while
  two independent clients enqueued six utterances: peak concurrency 1.
- **Voice cannot carry nine-way identity.** Every cloned candidate was rated
  1–10, then solved for the exact maximin subset by speaker-embedding cosine.
  The best available nine still contain a pair at 0.86; the whole 29-voice
  population spans only 0.74–0.90, because Chatterbox compresses everything it
  clones toward its own character. Sweeping the quality floor showed the
  tradeoff is nearly flat, so the pool is drawn from voices rated 8+ (mean 8.56)
  rather than trading real quality for 0.035 of inaudible separation. This is
  why the spoken label carries the load and the voice reinforces it.

## Verification

Four workspaces against a live daemon: distinct voices allocated in pool order,
labels spoken, assignments stable across a restart, and a previously unseen
workspace taking the next free voice rather than a duplicate. Also confirmed
stdio still works after the `main()` restructure, the `prefix` toggle and
`[voices]` pinning behave, and a `[voices]` section is not misparsed as a
channel.

## To adopt

Install the LaunchAgent and re-register the server as HTTP (both in the README).
Existing sessions stay on stdio until restarted.

## Known limitation

Past nine workspaces the voice pool wraps deterministically and two projects
share a voice; only the label separates them at that point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)