### PR TITLE
Hold one audio stream open; fix speed at 1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,15 +77,20 @@ queued narration has been overtaken by events.
 
 ## Channels
 
-Named profiles for speed and priority, so urgent speech jumps the queue.
-Defaults:
+Priority classes for the shared queue, so urgent speech jumps ahead of
+narration already waiting. Defaults:
 
-| Channel      | Speed | Priority    |
-| ------------ | ----- | ----------- |
-| `permission` | 1.0   | 1 (highest) |
-| `question`   | 1.0   | 2           |
-| `notify`     | 1.2   | 10          |
-| `narrate`    | 1.3   | 15          |
+| Channel      | Priority    |
+| ------------ | ----------- |
+| `permission` | 1 (highest) |
+| `question`   | 2           |
+| `notify`     | 10          |
+| `narrate`    | 15          |
+
+Speed is uniform at 1.1. Per-channel rates were a Kokoro-era idea that never
+earned its keep — the whole 1.0–1.3 range saved under half a second on a typical
+notification. A channel's meaning is carried by priority and by how the message
+is worded, not by how fast it is read.
 
 Override in `~/.config/tts-mcp-server/channels.toml`:
 
@@ -93,7 +98,6 @@ Override in `~/.config/tts-mcp-server/channels.toml`:
 # ref_audio = "/Users/you/.config/tts-mcp-server/voices/mine.wav"
 
 [narrate]
-speed = 1.4
 priority = 20
 ```
 
@@ -189,9 +193,12 @@ N × Claude Code  ──http──>  one daemon  ──>  Chatterbox Turbo  ─�
 - **Serialized synthesis.** MLX's Metal command buffer aborts the process if two
   threads evaluate concurrently, so all inference runs on a single dedicated
   thread. Costs nothing at ~190 ms per utterance.
+- **Persistent audio stream.** One `sounddevice` output stream stays open for
+  the process lifetime. Shelling out to `afplay` cost ~1.0 s of process and
+  CoreAudio startup per utterance — five times the synthesis time, paid on every
+  notification. Removing it also made `interrupt` near-instant (~50 ms).
 - **Speed at playback.** Chatterbox ignores a speed argument, so rate is applied
-  via `afplay -r`. Changing speed doesn't re-run inference.
-- **Temp files.** Audio is written to a temp WAV, played, then deleted.
+  by resampling before the device write, not by re-running inference.
 
 ## Troubleshooting
 
@@ -208,8 +215,9 @@ short. The server checks this up front.
 **First call slow:** the model is loading (~20 s). The daemon warms at startup;
 stdio mode loads lazily on first call.
 
-**`afplay` not found:** you're not on macOS. Replace the `afplay` call in
-`PlaybackQueue._play()` with your platform's player.
+**No audio from the daemon:** confirm it is a LaunchAgent, not a LaunchDaemon —
+only the former can reach the audio device. `sounddevice` errors surface in
+`/tmp/tts-mcp-server.err`.
 
 ## License
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,8 @@ requires-python = ">=3.12"
 dependencies = [
     "fastmcp>=2.0.0",
     "mlx-audio>=0.4.6",
+    "sounddevice>=0.5.0",
+    "numpy>=2.0",
     "soundfile>=0.12.1",
     "en_core_web_sm@https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.8.0/en_core_web_sm-3.8.0-py3-none-any.whl",
 ]

--- a/tts_server.py
+++ b/tts_server.py
@@ -1,9 +1,9 @@
 """TTS MCP Server for Claude Code notifications.
 
-Provides speech synthesis via MLX-audio and Kokoro-82M on Apple Silicon.
+Provides speech synthesis via MLX-audio and Chatterbox Turbo on Apple Silicon.
 Exposes a ``notify`` tool for task completion alerts, a ``speak`` tool for
-general-purpose TTS with voice/speed control, and an ``interrupt`` tool to
-cut off playback and discard the backlog.
+longer narration, and an ``interrupt`` tool to cut off playback and discard the
+backlog. Runs either as a per-session stdio server or as one shared daemon.
 """
 
 import argparse
@@ -15,8 +15,7 @@ import itertools
 import json
 import logging
 import pathlib
-import signal
-import tempfile
+import threading
 import time
 import tomllib
 import urllib.parse
@@ -24,6 +23,8 @@ from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 
 import mlx.core as mx
+import numpy as np
+import sounddevice
 import soundfile as sf
 from fastmcp import Context, FastMCP
 from mlx.nn.layers import Module
@@ -40,13 +41,29 @@ logger = logging.getLogger(__name__)
 # lower. Kokoro was 37 ms but capped us at a handful of distinguishable voices;
 # Turbo clones from a reference clip instead, which is what lets each workspace
 # sound different.
+#
+# Turbo has no emotion control, whatever the API suggests. `exaggeration` is
+# accepted by generate() and prepare_conditionals() and silently does nothing:
+# T3Config.turbo() sets emotion_adv=False, so the emotion_adv_fc projection is
+# never even constructed. Confirmed by measurement — varying it 0.0 to 1.0
+# changes the audio less than two identical calls differ from each other.
+# Base Chatterbox does support it and ships the weight, but costs 660 ms
+# against Turbo's 190 ms. Not worth it: channels are distinguished by priority
+# and by how the message is worded, and workspaces by voice and spoken label.
 SAMPLE_RATE = 24000
-SPEED = 1.2
+SPEED = 1.1
 HUGGINGFACE_REPO = "mlx-community/Chatterbox-Turbo-TTS-8bit"
 
-# Chatterbox ignores a speed argument, so rate lives at playback via `afplay -r`.
-# That decouples it from synthesis: changing speed no longer re-runs the model.
+# One rate for everything. Per-channel speeds were a Kokoro-era idea that never
+# earned its keep: the whole 1.0-to-1.3 range saved under half a second on a
+# typical notification, and a channel's meaning is better carried by how the
+# message is worded than by how fast it is read. Rate is applied at playback,
+# so changing it does not re-run the model.
 MIN_SPEED, MAX_SPEED = 0.5, 2.0
+
+# Samples handed to the device per write. Small enough that interrupt() cuts in
+# within ~85 ms, large enough not to churn.
+WRITE_CHUNK = 2048
 
 # Chatterbox rejects shorter reference clips outright ("Audio prompt must be
 # longer than 5 seconds!"), so catch it up front with a legible message.
@@ -68,7 +85,7 @@ DEFAULT_PORT = 8765
 
 
 # ---------------------------------------------------------------------------
-# Channels — named voice/speed/priority profiles
+# Channels — priority classes for the shared playback queue
 # ---------------------------------------------------------------------------
 
 
@@ -79,10 +96,10 @@ class Channel:
 
 
 DEFAULT_CHANNELS: dict[str, Channel] = {
-    "notify": Channel(speed=1.2, priority=10),
-    "permission": Channel(speed=1.0, priority=1),
-    "question": Channel(speed=1.0, priority=2),
-    "narrate": Channel(speed=1.3, priority=15),
+    "notify": Channel(speed=SPEED, priority=10),
+    "permission": Channel(speed=SPEED, priority=1),
+    "question": Channel(speed=SPEED, priority=2),
+    "narrate": Channel(speed=SPEED, priority=15),
 }
 
 
@@ -306,15 +323,20 @@ class PlaybackQueue:
             maxsize=maxsize
         )
         self._worker: asyncio.Task[None] | None = None
-        self._current: asyncio.subprocess.Process | None = None
+        self._stream: sounddevice.OutputStream | None = None
+        self._cut = threading.Event()
 
     def start(self) -> None:
-        """Start the background drain task."""
+        """Open the audio device once and start the background drain task."""
+        self._stream = sounddevice.OutputStream(
+            samplerate=SAMPLE_RATE, channels=1, dtype="float32"
+        )
+        self._stream.start()
         self._worker = asyncio.create_task(self._drain())
         logger.info("Playback worker started.")
 
     async def stop(self) -> None:
-        """Cancel the worker and clean up."""
+        """Cancel the worker and close the device."""
         if self._worker is not None:
             self._worker.cancel()
             try:
@@ -322,6 +344,10 @@ class PlaybackQueue:
             except asyncio.CancelledError:
                 pass
             self._worker = None
+        if self._stream is not None:
+            self._stream.stop()
+            self._stream.close()
+            self._stream = None
         logger.info("Playback worker stopped.")
 
     def enqueue(self, audio: mx.array, priority: int = 10, speed: float = 1.0) -> bool:
@@ -351,8 +377,7 @@ class PlaybackQueue:
                 break
             self._queue.task_done()
             dropped += 1
-        if self._current is not None and self._current.returncode is None:
-            self._current.terminate()
+        self._cut.set()
         return dropped
 
     async def _drain(self) -> None:
@@ -367,27 +392,25 @@ class PlaybackQueue:
                 self._queue.task_done()
 
     async def _play(self, audio: mx.array, speed: float = 1.0) -> None:
-        """Write audio to a temp WAV and play via afplay at the given rate."""
-        fd, name = tempfile.mkstemp(suffix=".wav", prefix="tts_")
-        path = pathlib.Path(name)
-        try:
-            await asyncio.to_thread(_write_wav, fd, audio)
-            proc = await asyncio.create_subprocess_exec(
-                "afplay",
-                "-r",
-                str(speed),
-                str(path),
-                stdout=asyncio.subprocess.DEVNULL,
-                stderr=asyncio.subprocess.PIPE,
-            )
-            self._current = proc
-            _, stderr = await proc.communicate()
-            # -SIGTERM is how interrupt() stops playback; not a failure.
-            if proc.returncode not in (0, -signal.SIGTERM):
-                raise RuntimeError(f"afplay failed: {stderr.decode()}")
-        finally:
-            self._current = None
-            path.unlink(missing_ok=True)
+        """Push samples to the already-open device.
+
+        This used to shell out to `afplay`, which cost ~1.0 s of process and
+        CoreAudio startup per utterance — five times the synthesis time, paid on
+        every single notification. Holding one stream open removes it entirely.
+        """
+        if self._stream is None:
+            raise RuntimeError("Audio stream is not open")
+        data = _at_speed(np.asarray(audio, dtype=np.float32).reshape(-1), speed)
+        self._cut.clear()
+        await asyncio.to_thread(self._write, data)
+
+    def _write(self, data: np.ndarray) -> None:
+        """Blocking write in chunks, so interrupt() can cut in mid-utterance."""
+        for i in range(0, len(data), WRITE_CHUNK):
+            if self._cut.is_set():
+                logger.debug("Playback cut short after %d samples", i)
+                return
+            self._stream.write(data[i : i + WRITE_CHUNK])
 
 
 _playback: PlaybackQueue | None = None
@@ -559,10 +582,19 @@ def generate(text: str, ref_audio: str | None = None) -> mx.array:
     return audio
 
 
-def _write_wav(fd: int, audio: mx.array) -> None:
-    """Write audio as WAV to an open descriptor, closing it afterwards."""
-    with open(fd, "wb") as f:
-        sf.write(f, audio, SAMPLE_RATE, format="WAV")
+def _at_speed(audio: np.ndarray, speed: float) -> np.ndarray:
+    """Resample for playback rate.
+
+    A plain rate change, so it shifts pitch slightly — the same thing
+    `afplay -r` did. Imperceptible at the 1.1 we actually use; a phase vocoder
+    would be the fix if we ever wanted large, pitch-preserving changes.
+    """
+    if abs(speed - 1.0) < 1e-3:
+        return audio
+    n = max(1, int(len(audio) / speed))
+    return np.interp(
+        np.linspace(0, len(audio) - 1, n), np.arange(len(audio)), audio
+    ).astype(np.float32)
 
 
 def _require_playback() -> PlaybackQueue:


### PR DESCRIPTION
Removes a fixed ~1.0 s cost from every utterance, and retires per-channel speed.

## The overhead nobody measured

Shelling out to `afplay` cost a fixed startup penalty per utterance, independent
of audio length:

| audio | afplay wall | overhead |
| ----- | ----------- | -------- |
| 0.05 s | 1.20 s | +1.15 s |
| 0.50 s | 1.69 s | +1.19 s |
| 1.00 s | 1.95 s | +0.95 s |
| 2.00 s | 2.95 s | +0.95 s |

That is five times the synthesis cost, paid on every notification. Nine agents
each sending one meant nine seconds of dead air on top of the speech.

It also reframes earlier work in this repo: the Kokoro-to-Turbo latency
analysis argued 37 ms against 190 ms while a 1000 ms constant sat unmeasured
next to it. The conclusion there (the speaker is the bottleneck, not the model)
was right, but the mechanism was misattributed to audio duration — a physical
limit — when much of it was process startup, which is fixable.

## Change

One `sounddevice` OutputStream stays open for the process lifetime; samples are
written into it directly.

| | before | after |
| --- | ------ | ----- |
| 6 utterances | ~13.8 s | **8.21 s** (1.37 s each — essentially just audio) |
| `interrupt` | subprocess SIGTERM | **0.05 s** |

Writing in 2048-sample chunks is what lets `interrupt` cut in mid-utterance.

Verified under launchd, which was the real risk: reaching the audio device from
a LaunchAgent is the kind of thing that works in a shell and fails in service
context. It doesn't.

## Speed fixed at 1.1

Per-channel rates never earned their keep. The entire 1.0–1.3 range saved under
half a second on a typical notification — less than half the playback overhead
sitting unnoticed beside it. A channel's meaning is better carried by priority
and by how the message is worded; that guidance lives in the user's config.

Priority is untouched, because it genuinely changes what you hear first.

Rate is now applied by resampling before the device write. That shifts pitch
slightly, exactly as `afplay -r` did — imperceptible at 1.1. A phase vocoder is
the fix if large pitch-preserving changes are ever wanted.

## Note for deployment

The editable install follows the checked-out tree, so a daemon restart while
`main` is checked out silently reverts to `afplay`. Merging closes that gap;
`launchctl kickstart -k gui/$(id -u)/com.tts-mcp-server` picks up changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)