### PR TITLE
Distinguish concurrent sessions sharing a workspace root

### DIFF
--- a/tts_server.py
+++ b/tts_server.py
@@ -249,21 +249,80 @@ class VoiceRegistry:
             logger.warning("Could not persist assignments to %s", self._path)
 
 
+ORDINALS = {
+    2: "two",
+    3: "three",
+    4: "four",
+    5: "five",
+    6: "six",
+    7: "seven",
+    8: "eight",
+    9: "nine",
+}
+
+# A slot is reclaimed once its session has been quiet this long. Sessions do not
+# announce that they are closing, and a reconnect arrives under a fresh id, so
+# expiry is the only signal that a slot is free again.
+SESSION_TTL = 1800.0
+
+
+class SessionSlots:
+    """Separates concurrent sessions that share one workspace root.
+
+    Several terminals open on the same directory is the normal case, not an
+    edge case — five of six sessions here. Without this they would share a
+    single voice and a single label and be indistinguishable, which is the
+    whole thing identity is supposed to prevent.
+    """
+
+    def __init__(self, ttl: float = SESSION_TTL) -> None:
+        self._ttl = ttl
+        self._seen: dict[tuple[str, str], tuple[int, float]] = {}
+        self._lock = threading.Lock()
+
+    def slot(self, root: str, session_id: str | None) -> int:
+        """Which concurrent session this is for that root, 1-based."""
+        if session_id is None:
+            return 1
+        now = time.monotonic()
+        with self._lock:
+            for key, (_, seen) in list(self._seen.items()):
+                if now - seen > self._ttl:
+                    del self._seen[key]
+            key = (root, session_id)
+            if key in self._seen:
+                slot = self._seen[key][0]
+            else:
+                taken = {s for (r, _), (s, _) in self._seen.items() if r == root}
+                slot = next(i for i in itertools.count(1) if i not in taken)
+            self._seen[key] = (slot, now)
+            return slot
+
+
 _registry = VoiceRegistry()
+_slots = SessionSlots()
 _voice_overrides: dict[str, str] = {}
 _prefix_enabled: bool = True
 
 
 async def identity(ctx: Context) -> tuple[str | None, str]:
-    """Resolve the caller's workspace into a voice and a spoken label.
+    """Resolve the caller's workspace and session into a voice and spoken label.
 
     :returns: (ref_audio path or None, label — empty when unidentifiable)
     """
     root = await workspace_root(ctx)
     if root is None:
         return _ref_audio, ""
-    label = pathlib.PurePath(root).name or "workspace"
-    preset = _voice_overrides.get(label) or _registry.voice(root)
+    slot = _slots.slot(root, ctx.session_id)
+    name = pathlib.PurePath(root).name or "workspace"
+    # The first session keeps the bare name, so a workspace with only one open
+    # is never called "spade one". Later ones are numbered, and nobody is ever
+    # renamed after the fact.
+    label = name if slot == 1 else f"{name} {ORDINALS.get(slot, str(slot))}"
+    # Voices are per slot, so the second terminal on a root sounds different
+    # from the first. An explicit [voices] pin applies to the first only.
+    override = _voice_overrides.get(name) if slot == 1 else None
+    preset = override or _registry.voice(root if slot == 1 else f"{root}#{slot}")
     clip = VOICES_DIR / f"{preset}.wav"
     if not clip.is_file():
         logger.warning("Voice clip %s missing — using configured default.", clip)

--- a/tts_server.py
+++ b/tts_server.py
@@ -249,16 +249,52 @@ class VoiceRegistry:
             logger.warning("Could not persist assignments to %s", self._path)
 
 
-ORDINALS = {
-    2: "two",
-    3: "three",
-    4: "four",
-    5: "five",
-    6: "six",
-    7: "seven",
-    8: "eight",
-    9: "nine",
-}
+# Concurrent sessions on one root are named rather than numbered. "cfd Bonnie"
+# and "cfd Colin" are far easier to tell apart mid-task than "cfd two" and
+# "cfd three", where the only contrast is an unstressed final syllable.
+#
+# From the NHC's 2028 Atlantic list, split by gender and ordered most-familiar
+# first. The name follows the gender of the assigned voice — a male name spoken
+# in a female voice is more confusing than a bare number. "Alex" is dropped
+# despite being on the list, being ambiguous in English.
+FEMALE_NAMES = (
+    "Bonnie",
+    "Danielle",
+    "Julia",
+    "Lisa",
+    "Nicole",
+    "Paula",
+    "Farrah",
+    "Hermine",
+    "Shary",
+    "Virginie",
+)
+MALE_NAMES = (
+    "Colin",
+    "Earl",
+    "Martin",
+    "Owen",
+    "Richard",
+    "Karl",
+    "Walter",
+    "Gaston",
+    "Idris",
+    "Tobias",
+)
+
+
+def _names_for_pool() -> dict[str, str]:
+    """One name per pooled voice, gender-matched.
+
+    Deriving the name from the voice rather than the slot number means the two
+    can never disagree, and distinct voices guarantee distinct names for free.
+    Kokoro presets encode gender in their second character (af_/am_/bf_/bm_).
+    """
+    women, men = iter(FEMALE_NAMES), iter(MALE_NAMES)
+    return {v: next(women if v[1] == "f" else men) for v in VOICE_POOL}
+
+
+VOICE_NAMES = _names_for_pool()
 
 # A slot is reclaimed once its session has been quiet this long. Sessions do not
 # announce that they are closing, and a reconnect arrives under a fresh id, so
@@ -305,6 +341,20 @@ _voice_overrides: dict[str, str] = {}
 _prefix_enabled: bool = True
 
 
+def _session_name(preset: str, slot: int) -> str:
+    """Spoken name for a session, matching the gender of its voice.
+
+    Falls back to the slot number for a voice outside the pool — an explicit
+    [voices] pin, say — rather than risk a mismatched name.
+    """
+    if preset in VOICE_NAMES:
+        return VOICE_NAMES[preset]
+    if len(preset) > 1 and preset[1] in "fm":
+        pool = FEMALE_NAMES if preset[1] == "f" else MALE_NAMES
+        return pool[slot % len(pool)]
+    return str(slot)
+
+
 async def identity(ctx: Context) -> tuple[str | None, str]:
     """Resolve the caller's workspace and session into a voice and spoken label.
 
@@ -315,14 +365,14 @@ async def identity(ctx: Context) -> tuple[str | None, str]:
         return _ref_audio, ""
     slot = _slots.slot(root, ctx.session_id)
     name = pathlib.PurePath(root).name or "workspace"
-    # The first session keeps the bare name, so a workspace with only one open
-    # is never called "spade one". Later ones are numbered, and nobody is ever
-    # renamed after the fact.
-    label = name if slot == 1 else f"{name} {ORDINALS.get(slot, str(slot))}"
     # Voices are per slot, so the second terminal on a root sounds different
     # from the first. An explicit [voices] pin applies to the first only.
     override = _voice_overrides.get(name) if slot == 1 else None
     preset = override or _registry.voice(root if slot == 1 else f"{root}#{slot}")
+    # Resolved after the voice, because the name has to match its gender. The
+    # first session keeps the bare workspace name, so a workspace with only one
+    # open is never called "spade Colin", and nobody is renamed after the fact.
+    label = name if slot == 1 else f"{name} {_session_name(preset, slot)}"
     clip = VOICES_DIR / f"{preset}.wav"
     if not clip.is_file():
         logger.warning("Voice clip %s missing — using configured default.", clip)


### PR DESCRIPTION
Identity keyed on the workspace root alone, which collapses in the case that
turns out to be normal rather than exceptional: **five of six live sessions run
from the same directory.** All five would have been given one voice and one
label — "cfd, tests passed" five times over, indistinguishable. That is exactly
what identity exists to prevent.

Same-root collision was flagged as a known risk when root-based identity was
chosen, with session id named as the tiebreaker. That fallback was never built.

## Change

Sessions sharing a root get 1-based slots, each with its own voice and its own
spoken name. The first keeps the bare workspace name, so a workspace with a
single session open is never called "spade Colin", and nobody is renamed after
the fact.

Names come from the NHC's 2028 Atlantic list and are **derived from the assigned
voice, not the slot number**, so the two can never disagree — a male name in a
female voice would be worse than a bare number. Distinct voices then give
distinct names for free.

Verified with five concurrent Claude Code clients from one directory:

| label | voice | |
| ----- | ----- | - |
| `cfd` | af_heart | female |
| `cfd Danielle` | af_jessica | female |
| `cfd Julia` | af_sarah | female |
| `cfd Colin` | am_liam | male |
| `cfd Lisa` | bf_isabella | female |

## Slot lifetime

Slots expire after 30 minutes of silence. Sessions do not announce that they are
closing, and a reconnect arrives under a fresh id, so expiry is the only signal
a slot is free again.

The cost: rapid open/close cycles climb slot numbers until the TTL catches up.
Bounded, and preferable to reusing a slot while its session is still live.

An explicit `[voices]` pin applies to slot 1 only; later slots draw from the
pool. A pinned voice outside the pool falls back to its gender prefix for a
name, or to the slot number if it has none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)