### PR TITLE
Follow the default output device without a restart

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,7 @@ N × Claude Code  ──http──>  one daemon  ──>  Chatterbox Turbo  ─�
 | ------------- | ---------------------------------------------------- |
 | `config.py`   | The TOML file: reference voice, channel priorities   |
 | `identity.py` | Workspace roots, voice assignment, session slots     |
+| `device.py`   | Which output device is current, and telling PortAudio |
 | `synth.py`    | Model loading, conditionals, inference               |
 | `playback.py` | Priority queue, audio device, resampling             |
 | `server.py`   | MCP tools, lifecycle, command line                   |
@@ -232,6 +233,66 @@ N × Claude Code  ──http──>  one daemon  ──>  Chatterbox Turbo  ─�
   notification. Removing it also made `interrupt` near-instant, about 50 ms.
 - **Rate at playback.** Chatterbox ignores a speed argument, so the server
   resamples before the device write instead of running inference again.
+- **The stream follows the output device.** See below — holding one stream open
+  is what made this need saying at all.
+
+### Following the output device
+
+Connect a headset to a running daemon and speech has to move to it. Under
+`afplay` this was free: a new process picked up the current default output every
+time. One stream held open for the life of the daemon gives that up, because
+PortAudio decides two things when it initializes and never revisits either —
+what hardware exists, and which of it is "the default output". A stream opened at
+login therefore keeps writing to the speakers, and the headset is not even in the
+device list to switch to.
+
+Re-initializing PortAudio refreshes both. It cannot be what *detects* the change,
+though, because it leaves every open stream a dangling pointer. So the two jobs
+go to the two APIs that can do them:
+
+- **CoreAudio says whether the output moved.** One HAL property read for the
+  default device's id, about 15 µs, and harmless to an open stream. Cheap enough
+  to ask before every utterance, which is the right cadence: between utterances
+  there is no playback for a reopen to interrupt.
+- **PortAudio gets re-initialized, then asked for its own default.** It reads the
+  same CoreAudio property, so after the re-scan the two agree by construction and
+  there is no device name to match up.
+
+The reopen — abort, close, re-scan, open — costs 130 to 190 ms depending on the
+device, paid only when it actually changed. The id is a token compared for
+equality and nothing else. PortAudio names the device for the log line, which is
+the same string CoreAudio would give and a fortieth of the cost.
+
+**The id is a token and not a name because names are not unique.** One soundcore
+headset registers twice under a single name, and both entries are outputs
+PortAudio will happily open. Matching a CoreAudio name against PortAudio's device
+list would be a coin flip on exactly the hardware this feature exists for.
+
+A short write with no interrupt pending means the device went away mid-utterance:
+the headset walked out of range. That reopens once and finishes the rest of the
+utterance on whatever is default now, rather than dropping it.
+
+`device.py` calls `sounddevice._terminate` and `_initialize`, which are private.
+There is no public way to make PortAudio re-read the hardware.
+
+**Why not drop the persistent stream instead?** Opening a fresh stream per
+utterance would delete this whole module: PortAudio re-reads its default every
+time, so audio lands on the current device with no probe, no token, and no
+CoreAudio. Measured, it costs 247 ms an utterance on Bluetooth against 42 ms for
+a write to a stream already open. That is more than the 190 ms of synthesis in
+front of it, on every notification, to save fifty lines. `afplay`'s 1.0 s was
+process and framework startup; a fresh in-process stream is far cheaper than that
+and still not cheap. The held-open stream earns its complexity, and it earns it on
+the Bluetooth headset rather than in the general case.
+
+**Why not a CoreAudio property listener?** Push instead of poll would replace a
+15 µs read with a flag, and cost a C callback into Python, a run loop, and
+mutable state written from a CoreAudio thread. There is no latency to win: the
+poll is already free at the only cadence that matters.
+
+**Why not reopen speculatively, while idle?** It would hide the 190 ms from the
+first utterance after a switch. It also needs a timer and a background task to
+own it, which is real structure for a saving David sees a few times a day.
 
 ## Development
 
@@ -242,7 +303,14 @@ uv run --group dev ruff format .
 ```
 
 The tests cover config loading, voice and slot assignment, spoken labels, queue
-ordering, and resampling. None of them load the model or open the audio device.
+ordering, resampling, and output-device selection. None of them load the model.
+
+`test_device.py` is the one file that touches real hardware, and has to: every
+claim the device-following design rests on is a claim about what CoreAudio and
+PortAudio actually do, and a mock would only restate the assumption. It opens a
+stream, times the HAL probe, and asserts that a re-scan invalidates an open
+stream. Those tests skip off macOS.
+
 
 ## Troubleshooting
 

--- a/maggid/device.py
+++ b/maggid/device.py
@@ -1,0 +1,141 @@
+"""Whether the output device moved, and making PortAudio notice that it did.
+
+PortAudio decides two things when it initializes and never revisits either: what
+hardware exists, and which of it is "the default output". A stream held open
+across a Bluetooth headset connecting therefore keeps writing to the speakers it
+was born on, and the headset is not even in the device list to switch to.
+
+Re-initializing PortAudio refreshes both, because it re-reads the same CoreAudio
+property. But it invalidates every open stream, so it cannot be what *notices* a
+change -- and holding one stream open is worth about 200 ms an utterance on
+Bluetooth, so giving that up to keep this module simple is not a trade available.
+CoreAudio answers the other half directly: one property read, harmless to an open
+stream, cheap enough to do before every utterance.
+
+So the split is: CoreAudio says *whether* the output moved, PortAudio gets kicked
+so it can follow. Only the first needs the HAL, and it needs one integer from it.
+Naming the device is PortAudio's job -- after a re-scan the two agree by
+construction, and PortAudio knows the name of the device it actually opened.
+"""
+
+import ctypes
+import ctypes.util
+import logging
+import struct
+import sys
+
+import sounddevice
+
+logger = logging.getLogger(__name__)
+
+
+def default_output() -> int | None:
+    """CoreAudio's id for the device macOS would play on right now.
+
+    An opaque token: compared for equality against the one a stream was opened
+    on, and nothing else. The id rather than the display name because names are
+    not unique and this is the one place that would silently do the wrong thing
+    about it -- one Bluetooth headset can register twice, under one name, and
+    both entries can be outputs PortAudio will happily open.
+
+    :returns: None when the platform, the probe, or the machine cannot answer,
+        which callers should read as "no opinion" and leave to PortAudio.
+    """
+    if sys.platform != "darwin" or _core_audio is None:
+        return None
+    address = _PropertyAddress(_DEFAULT_OUTPUT_DEVICE, _SCOPE_GLOBAL, _ELEMENT_MAIN)
+    into = ctypes.c_uint32()
+    size = ctypes.c_uint32(ctypes.sizeof(into))
+    status = _core_audio.AudioObjectGetPropertyData(
+        _SYSTEM_OBJECT,
+        ctypes.byref(address),
+        0,
+        None,
+        ctypes.byref(size),
+        ctypes.byref(into),
+    )
+    if status != 0:
+        logger.debug("Could not read the default output device: %d", status)
+        return None
+    # kAudioObjectUnknown is zero, which is how a machine with no output device
+    # at all answers. Same meaning as a failed read.
+    return into.value or None
+
+
+def output_name() -> str:
+    """What PortAudio calls the device it just opened, for the log line.
+
+    Meaningful only straight after a `rescan`, since that is the only moment
+    PortAudio's idea of "the default output" is current. That is also the only
+    place it is called, which is why this reads a cache rather than the hardware.
+
+    Asked of PortAudio and not the HAL: after the re-scan it is the same answer,
+    it costs 1 us against 43 us, and it names the device actually opened rather
+    than the one a probe saw a moment earlier. Getting it from CoreAudio instead
+    would mean a second framework, a CFString to own and release, and a Boolean
+    return whose upper bits arm64 leaves undefined -- all to duplicate a string
+    PortAudio is already holding.
+    """
+    try:
+        return sounddevice.query_devices(kind="output")["name"]
+    except (sounddevice.PortAudioError, ValueError, KeyError) as error:
+        logger.debug("PortAudio would not name its default output: %s", error)
+        return "an unnamed device"
+
+
+def rescan() -> None:
+    """Make PortAudio re-read the hardware, and with it "the default output".
+
+    The only way to refresh either, and it leaves every open stream a dangling
+    pointer that raises on the next write. Close first.
+    """
+    sounddevice._terminate()
+    sounddevice._initialize()
+
+
+# --- CoreAudio, via ctypes -------------------------------------------------
+#
+# One property read is not enough of the HAL to justify a dependency on pyobjc,
+# which would pull in the whole bridge to fetch a single integer.
+
+
+def _fourcc(code: str) -> int:
+    """A CoreAudio selector, which are four-byte ASCII constants."""
+    return struct.unpack(">I", code.encode())[0]
+
+
+_SYSTEM_OBJECT = 1  # kAudioObjectSystemObject
+_DEFAULT_OUTPUT_DEVICE = _fourcc("dOut")
+_SCOPE_GLOBAL = _fourcc("glob")
+_ELEMENT_MAIN = 0
+
+
+class _PropertyAddress(ctypes.Structure):
+    """AudioObjectPropertyAddress: what to read, in which scope."""
+
+    _fields_ = [
+        ("selector", ctypes.c_uint32),
+        ("scope", ctypes.c_uint32),
+        ("element", ctypes.c_uint32),
+    ]
+
+
+def _core_audio_framework() -> ctypes.CDLL | None:
+    if sys.platform != "darwin":
+        return None
+    path = ctypes.util.find_library("CoreAudio")
+    return ctypes.CDLL(path) if path else None
+
+
+_core_audio = _core_audio_framework()
+
+if _core_audio is not None:
+    _core_audio.AudioObjectGetPropertyData.argtypes = [
+        ctypes.c_uint32,
+        ctypes.POINTER(_PropertyAddress),
+        ctypes.c_uint32,
+        ctypes.c_void_p,
+        ctypes.POINTER(ctypes.c_uint32),
+        ctypes.c_void_p,
+    ]
+    _core_audio.AudioObjectGetPropertyData.restype = ctypes.c_int32

--- a/maggid/playback.py
+++ b/maggid/playback.py
@@ -11,6 +11,8 @@ import mlx.core as mx
 import numpy as np
 import sounddevice
 
+from . import device
+
 logger = logging.getLogger(__name__)
 
 SAMPLE_RATE = 24000
@@ -49,28 +51,27 @@ class PlaybackQueue:
         )
         self._worker: asyncio.Task[None] | None = None
         self._stream: sounddevice.OutputStream | None = None
+        self._device: int | None = None
         self._cut = threading.Event()
 
     def start(self) -> None:
         """Open the audio device and start the drain task."""
-        self._stream = sounddevice.OutputStream(
-            samplerate=SAMPLE_RATE, channels=1, dtype="float32"
-        )
-        self._stream.start()
+        self._open()
         self._worker = asyncio.create_task(self._drain())
         logger.info("Playback worker started.")
 
     async def stop(self) -> None:
         """Cancel the worker and close the device."""
+        # Cut first. Cancelling the task does not interrupt the thread it handed
+        # the utterance to, so without this the close below can land while that
+        # thread is still inside a blocking write.
+        self._cut.set()
         if self._worker is not None:
             self._worker.cancel()
             with contextlib.suppress(asyncio.CancelledError):
                 await self._worker
             self._worker = None
-        if self._stream is not None:
-            self._stream.stop()
-            self._stream.close()
-            self._stream = None
+        self._close()
         logger.info("Playback worker stopped.")
 
     def enqueue(self, audio: mx.array, priority: int) -> bool:
@@ -113,26 +114,111 @@ class PlaybackQueue:
                 self._queue.task_done()
 
     async def _play(self, audio: mx.array) -> None:
-        """Push samples to the open device.
+        """Push samples to the device, whichever one that currently is.
 
         This used to shell out to `afplay`, which cost about 1.0 s of process and
         CoreAudio startup per utterance. That is five times the synthesis time,
         paid on every notification. One stream held open removes it.
+
+        Holding it open costs something the `afplay` version got for free, and
+        the whole of `_deliver` is about buying that back: a new process picked up
+        the default output device every time, so plugging in headphones simply
+        worked. See `_open`.
         """
-        stream = self._stream
-        if stream is None:
-            raise RuntimeError("Audio stream is not open")
         data = resampled(np.asarray(audio, dtype=np.float32).reshape(-1))
         self._cut.clear()
-        await asyncio.to_thread(self._write, stream, data)
+        # Threaded because the writes block for as long as the utterance takes to
+        # play. Holding the event loop for those seconds would stall every
+        # concurrent tool call behind whatever is speaking.
+        await asyncio.to_thread(self._deliver, data)
 
-    def _write(self, stream: sounddevice.OutputStream, data: np.ndarray) -> None:
-        """Write in chunks, so interrupt can cut in mid-utterance."""
-        for start in range(0, len(data), WRITE_CHUNK):
+    def _deliver(self, data: np.ndarray) -> None:
+        """Play a whole utterance, following the output device if it moves."""
+        written = self._write(self._current_stream(), data)
+        if written == len(data) or self._cut.is_set():
+            return
+        # Short write with nothing cutting in means the device went away
+        # mid-utterance: the headset walked out of range, the dock was pulled.
+        # Finish on whatever is default now, and only try once -- a second
+        # failure is a real fault, not a device change, and retrying it would
+        # spin.
+        #
+        # Closed explicitly, because the probe may still name this device: macOS
+        # can take a moment to promote a replacement, and `_current_stream` would
+        # otherwise see no change and hand back the same dead stream.
+        logger.info("Output device went away mid-utterance. Resuming on the new one.")
+        self._close()
+        self._write(self._current_stream(), data, written)
+
+    def _current_stream(self) -> sounddevice.OutputStream:
+        """The open stream, bound to the device macOS would play on now.
+
+        Checked before every utterance rather than on a timer. The check is about
+        15 us and the reopen it guards 130 to 190 ms depending on the device, so
+        checking less often saves nothing measurable, and a timer would go on
+        playing to a device David stopped listening to until it next fired. Per
+        utterance is also the only cadence at which a reopen is free of
+        consequence: between utterances there is nothing playing to interrupt.
+        """
+        if self._stream is None or device.default_output() != self._device:
+            return self._open()
+        return self._stream
+
+    def _open(self) -> sounddevice.OutputStream:
+        """Bind a fresh stream to whatever macOS currently plays on.
+
+        By PortAudio's own default, but only ever just after a `rescan` -- which
+        is the whole trick, because that is what makes "PortAudio's default"
+        current. It re-reads the same CoreAudio property the probe reads, so the
+        two agree by construction and there is no name to match up.
+        """
+        # Probed before the re-scan, so a switch during the reopen reads as a
+        # difference on the next utterance rather than as one already handled.
+        wanted = device.default_output()
+        self._close()
+        device.rescan()
+        self._stream = sounddevice.OutputStream(
+            samplerate=SAMPLE_RATE, channels=1, dtype="float32"
+        )
+        self._stream.start()
+        self._device = wanted
+        logger.info("Playback on %s.", device.output_name())
+        return self._stream
+
+    def _close(self) -> None:
+        """Release the device, tolerating one that has already disappeared.
+
+        Aborts rather than stops. `stop` waits for the device to drain, which is
+        about 90 ms of the reopen and is spent playing the tail of the last
+        utterance to the speakers David just walked away from -- or, when the
+        device has physically gone, waiting on hardware that will never drain.
+        Nothing here ever closes a device it means to keep listening to.
+        """
+        if self._stream is not None:
+            with contextlib.suppress(sounddevice.PortAudioError):
+                self._stream.abort()
+                self._stream.close()
+        self._stream = None
+        self._device = None
+
+    def _write(
+        self, stream: sounddevice.OutputStream, data: np.ndarray, start: int = 0
+    ) -> int:
+        """Write in chunks, so interrupt can cut in mid-utterance.
+
+        :returns: How far it got. Short of `len(data)` means either an interrupt
+            or a device that stopped accepting samples.
+        """
+        for offset in range(start, len(data), WRITE_CHUNK):
             if self._cut.is_set():
-                logger.debug("Cut playback after %d samples.", start)
-                return
-            stream.write(data[start : start + WRITE_CHUNK])
+                logger.debug("Cut playback after %d samples.", offset)
+                return offset
+            try:
+                stream.write(data[offset : offset + WRITE_CHUNK])
+            except sounddevice.PortAudioError as error:
+                logger.warning("Device stopped accepting samples: %s", error)
+                return offset
+        return len(data)
 
 
 def resampled(audio: np.ndarray, speed: float = SPEED) -> np.ndarray:

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -1,0 +1,108 @@
+"""Tests for the CoreAudio probe and the PortAudio re-scan.
+
+The only tests in the suite that touch real hardware. They have to: every claim
+the device-following design rests on is a claim about what CoreAudio and
+PortAudio actually do, and a mock would only restate the assumption.
+"""
+
+import sys
+import time
+
+import numpy as np
+import pytest
+import sounddevice
+
+from maggid import device
+
+darwin_only = pytest.mark.skipif(sys.platform != "darwin", reason="CoreAudio")
+
+
+@darwin_only
+def test_the_probe_answers_with_a_device():
+    assert device.default_output() is not None
+
+
+@darwin_only
+def test_a_re_scan_makes_portaudio_agree_with_the_probe():
+    """The load-bearing claim: PortAudio reads the same property the probe does.
+
+    Which is why `_open` can pass no device at all and land on the right one, and
+    why the name can come from PortAudio. If this ever failed, following the
+    output would have to match a CoreAudio name against PortAudio's device list
+    -- which is not even well defined, since names are not unique.
+    """
+    device.rescan()
+    default = sounddevice.query_devices(sounddevice.default.device[1])
+    assert device.output_name() == default["name"]
+    assert default["max_output_channels"] > 0
+
+
+@darwin_only
+def test_the_probe_leaves_an_open_stream_playing():
+    """The whole reason not to re-scan per utterance. Contrast the next test."""
+    stream = sounddevice.OutputStream(samplerate=24000, channels=1, dtype="float32")
+    stream.start()
+    try:
+        assert device.default_output() is not None
+        assert stream.active
+    finally:
+        stream.stop()
+        stream.close()
+
+
+@darwin_only
+def test_a_re_scan_invalidates_an_open_stream():
+    """Why `_open` closes before it re-scans: the old handle dangles."""
+    stream = sounddevice.OutputStream(samplerate=24000, channels=1, dtype="float32")
+    stream.start()
+    try:
+        device.rescan()
+        with pytest.raises(sounddevice.PortAudioError):
+            stream.write(np.zeros(2048, dtype=np.float32))
+    finally:
+        stream.close()
+
+
+@darwin_only
+def test_the_probe_is_cheap_enough_to_call_every_utterance():
+    """Guards the design: costing anything near a reopen would sink it."""
+    start = time.perf_counter()
+    for _ in range(50):
+        device.default_output()
+    assert (time.perf_counter() - start) / 50 < 0.001
+
+
+@darwin_only
+def test_one_headset_can_register_twice_under_one_name():
+    """Why the token is an id. Not a hypothetical: soundcore does exactly this.
+
+    Skipped when no duplicate happens to be attached, since it asserts about the
+    machine rather than about maggid. It is here to record what the id is for.
+    """
+    names = [
+        info["name"]
+        for info in sounddevice.query_devices()
+        if info["max_output_channels"] > 0
+    ]
+    if len(names) == len(set(names)):
+        pytest.skip("no duplicate output names attached right now")
+    assert device.default_output() is not None, "an id still identifies one of them"
+
+
+def test_the_probe_declines_politely_off_darwin(monkeypatch):
+    monkeypatch.setattr(device.sys, "platform", "linux")
+    assert device.default_output() is None
+
+
+def test_a_failing_probe_declines_rather_than_raising(monkeypatch):
+    """A HAL error must degrade to PortAudio's default, never break playback."""
+    monkeypatch.setattr(device, "_core_audio", None)
+    assert device.default_output() is None
+
+
+def test_an_unnameable_default_still_gives_the_log_line_something(monkeypatch):
+    def explode(**_kwargs):
+        raise ValueError("no default output device")
+
+    monkeypatch.setattr(device.sounddevice, "query_devices", explode)
+    assert device.output_name() == "an unnamed device"

--- a/tests/test_playback.py
+++ b/tests/test_playback.py
@@ -4,6 +4,7 @@ import asyncio
 
 import mlx.core as mx
 import numpy as np
+import sounddevice as sd
 
 from maggid import playback
 
@@ -58,6 +59,181 @@ def test_clear_cuts_the_utterance_in_flight():
     assert not queue._cut.is_set()
     queue.clear()
     assert queue._cut.is_set()
+
+
+class _FakeStream:
+    """An output stream that records what it was written, and can go away."""
+
+    def __init__(self, fail_after: int | None = None) -> None:
+        self.written = 0
+        self.closed = False
+        self._fail_after = fail_after
+
+    def write(self, data: np.ndarray) -> None:
+        if self._fail_after is not None and self.written >= self._fail_after:
+            raise sd.PortAudioError("device unplugged")
+        self.written += len(data)
+
+    def abort(self) -> None:
+        pass
+
+    def close(self) -> None:
+        self.closed = True
+
+
+SPEAKERS, HEADPHONES = 99, 113  # CoreAudio device ids, as the probe returns them
+
+
+def _wired(queue, monkeypatch, current: int | None, opened: list) -> None:
+    """Point the queue at a device id and record every stream it opens."""
+    monkeypatch.setattr(playback.device, "default_output", lambda: current)
+
+    def open_stream():
+        queue._close()
+        queue._stream, queue._device = _FakeStream(), playback.device.default_output()
+        opened.append(queue._device)
+        return queue._stream
+
+    monkeypatch.setattr(queue, "_open", open_stream)
+
+
+def test_a_steady_device_reuses_the_open_stream(monkeypatch):
+    """The reopen must not be paid when nothing moved."""
+    queue = playback.PlaybackQueue()
+    opened = []
+    _wired(queue, monkeypatch, SPEAKERS, opened)
+    first = queue._current_stream()
+    for _ in range(5):
+        assert queue._current_stream() is first
+    assert opened == [SPEAKERS]
+
+
+def test_a_switched_device_reopens_the_stream(monkeypatch):
+    """Headphones connect between utterances: follow them."""
+    queue = playback.PlaybackQueue()
+    opened = []
+    _wired(queue, monkeypatch, SPEAKERS, opened)
+    speakers = queue._current_stream()
+
+    monkeypatch.setattr(playback.device, "default_output", lambda: HEADPHONES)
+    headphones = queue._current_stream()
+
+    assert headphones is not speakers
+    assert speakers.closed
+    assert opened == [SPEAKERS, HEADPHONES]
+
+
+def test_two_devices_sharing_a_name_are_still_two_devices(monkeypatch):
+    """Why the token is an id. A soundcore headset registers twice, as one name."""
+    queue = playback.PlaybackQueue()
+    opened = []
+    _wired(queue, monkeypatch, 115, opened)
+    queue._current_stream()
+    monkeypatch.setattr(playback.device, "default_output", lambda: 121)
+    queue._current_stream()
+    assert opened == [115, 121]
+
+
+def test_an_unreadable_probe_still_opens_once(monkeypatch):
+    """No CoreAudio answer means one stream on PortAudio's default, not a churn."""
+    queue = playback.PlaybackQueue()
+    opened = []
+    _wired(queue, monkeypatch, None, opened)
+    first = queue._current_stream()
+    assert queue._current_stream() is first
+    assert opened == [None]
+
+
+def test_opening_closes_before_it_re_scans(monkeypatch):
+    """Ordering is load-bearing: a re-scan leaves an open stream dangling."""
+    order: list[str] = []
+
+    class _Noisy(_FakeStream):
+        def close(self) -> None:
+            order.append("close")
+            super().close()
+
+        def start(self) -> None:
+            order.append("start")
+
+    queue = playback.PlaybackQueue()
+    queue._stream, queue._device = _Noisy(), SPEAKERS
+    monkeypatch.setattr(playback.device, "default_output", lambda: HEADPHONES)
+    monkeypatch.setattr(playback.device, "rescan", lambda: order.append("rescan"))
+    monkeypatch.setattr(playback.sounddevice, "OutputStream", lambda **_kw: _Noisy())
+
+    queue._open()
+
+    assert order == ["close", "rescan", "start"]
+    assert queue._device == HEADPHONES
+
+
+def test_a_full_utterance_reports_every_sample(monkeypatch):
+    queue = playback.PlaybackQueue()
+    stream = _FakeStream()
+    data = np.zeros(playback.WRITE_CHUNK * 3, dtype=np.float32)
+    assert queue._write(stream, data) == len(data)
+    assert stream.written == len(data)
+
+
+def test_a_lost_device_reports_how_far_it_got():
+    queue = playback.PlaybackQueue()
+    stream = _FakeStream(fail_after=playback.WRITE_CHUNK)
+    data = np.zeros(playback.WRITE_CHUNK * 4, dtype=np.float32)
+    assert queue._write(stream, data) == playback.WRITE_CHUNK
+
+
+def test_an_interrupt_reports_how_far_it_got():
+    queue = playback.PlaybackQueue()
+    queue._cut.set()
+    data = np.zeros(playback.WRITE_CHUNK * 4, dtype=np.float32)
+    assert queue._write(_FakeStream(), data) == 0
+
+
+def test_a_device_lost_mid_utterance_finishes_on_the_new_one(monkeypatch):
+    """Headphones die while speaking: play the rest, don't repeat the start."""
+    queue = playback.PlaybackQueue()
+    data = np.zeros(playback.WRITE_CHUNK * 4, dtype=np.float32)
+    monkeypatch.setattr(playback.device, "default_output", lambda: SPEAKERS)
+    streams = [_FakeStream(fail_after=playback.WRITE_CHUNK), _FakeStream()]
+
+    def open_stream():
+        queue._stream, queue._device = streams[len(opened)], SPEAKERS
+        opened.append(SPEAKERS)
+        return queue._stream
+
+    opened: list = []
+    monkeypatch.setattr(queue, "_open", open_stream)
+
+    queue._deliver(data)
+
+    assert len(opened) == 2, "should have reopened once"
+    assert streams[0].written + streams[1].written == len(data)
+
+
+def test_an_interrupt_does_not_look_like_a_lost_device(monkeypatch):
+    """A cut is a short write too, but must not trigger a reopen."""
+    queue = playback.PlaybackQueue()
+    queue._cut.set()
+    opened: list = []
+    _wired(queue, monkeypatch, SPEAKERS, opened)
+
+    queue._deliver(np.zeros(playback.WRITE_CHUNK * 4, dtype=np.float32))
+
+    assert len(opened) == 1, "reopened on an interrupt"
+
+
+def test_closing_tolerates_a_device_that_already_vanished(monkeypatch):
+    queue = playback.PlaybackQueue()
+
+    class _Gone(_FakeStream):
+        def abort(self):
+            raise sd.PortAudioError("device is gone")
+
+    queue._stream, queue._device = _Gone(), SPEAKERS
+    queue._close()
+    assert queue._stream is None
+    assert queue._device is None
 
 
 def test_resampled_shortens_by_the_rate():


### PR DESCRIPTION
Connect a headset to a running daemon and speech kept going to the speakers. The
only fix was to restart the daemon, which costs the 20-second model load. This
makes the stream follow the output device instead.

## Why it was broken

PortAudio decides two things when it initializes and never revisits either: what
hardware exists, and which of it is "the default output". One stream held open
for the life of the daemon therefore keeps writing to the device it was born on,
and a headset connected since is not even in the device list to switch to.

Under `afplay` this was free — a new process picked up the current default every
time. Holding one stream open is what gave it up, and this branch is about buying
it back without giving up the stream.

## How

Re-initializing PortAudio refreshes both, because it re-reads the same CoreAudio
property. But it leaves every open stream a dangling pointer, so it cannot be
what *notices* a change. The two halves go to the two APIs that can do them:

- **CoreAudio says whether the output moved.** One HAL property read for the
  default device's id — about 15 µs, harmless to an open stream, so it runs
  before every utterance. That is the right cadence, because between utterances
  there is no playback for a reopen to interrupt.
- **PortAudio gets re-initialized, then opened on its own default.** It reads the
  same CoreAudio property, so after the re-scan the two agree by construction and
  there is no device name to match up.

A short write with no interrupt pending means the device went away mid-utterance
— the headset walked out of range. That reopens once and finishes the rest of the
utterance rather than dropping it.

`device.py` calls `sounddevice._terminate` and `_initialize`, which are private.
There is no public way to make PortAudio re-read the hardware.

## The token is a device id, not a display name

Names are not unique. **One soundcore headset registers twice under a single
name**, ids 115 and 121, and both entries are outputs PortAudio will happily
open:

```
   121 'soundcore Liberty 5'   portaudio_output=True
   115 'soundcore Liberty 5'   portaudio_output=True
   111 'USB Audio'             portaudio_output=False
   112 'USB Audio'             portaudio_output=False
```

Matching a CoreAudio name against PortAudio's device list would be a coin flip on
exactly the hardware this feature exists for. The id also costs a third as much
to read, since a name is a CFString to allocate, copy and release.

## Measurements

Everything here was measured on this machine rather than reasoned about, and two
of the numbers changed the design.

| | |
| --- | --- |
| change probe (device id) | 13 µs |
| change probe (display name) | 46 µs |
| PortAudio `_terminate` + `_initialize` | 3–9 ms |
| full reopen, MacBook Pro Speakers | 126 ms |
| full reopen, Bluetooth headset | 186 ms |
| write to an already-open stream | 42 ms |
| fresh stream per utterance, Bluetooth | 247 ms |

**Closing aborts rather than stops.** `stop` waits for the device to drain, which
was 90 ms of a 130 ms reopen — spent playing the tail of the last utterance to
speakers already walked away from, or, on a device that physically left, waiting
on hardware that will never drain. Nothing here closes a device it means to keep
listening to.

## Rejected alternatives

**Drop the held-open stream; open per utterance.** This deletes the whole module
— PortAudio re-reads its default every time, so audio lands on the current device
with no probe, no token, no CoreAudio, no ctypes. It is the design I wanted. It
costs 247 ms an utterance on Bluetooth against 42 ms for a write to a stream
already open: more than the 190 ms of synthesis in front of it, on every
notification, to save fifty lines. `afplay`'s 1.0 s was process and framework
startup; a fresh in-process stream is much cheaper than that and still not cheap.
The held-open stream earns its complexity, and it earns it on the headset rather
than in the general case.

**A CoreAudio property listener.** Push instead of poll replaces a 15 µs read
with a flag, and costs a C callback into Python, a run loop, and mutable state
written from a CoreAudio thread. There is no latency to win.

**Reopen speculatively while idle.** Would hide the 186 ms from the first
utterance after a switch, but needs a timer and a task to own it — real structure
for a saving that lands a few times a day.

**Name the device via CoreFoundation.** PortAudio already holds the string, at
1 µs against 43 µs, and it names the device actually opened rather than one
probed a moment earlier. Going to the HAL for it would mean a second framework, a
CFString to own and release, and a `Boolean` return whose upper bits arm64 leaves
undefined.

## Tests

`test_device.py` is the only file in the suite that touches real hardware, and
has to: every claim above is a claim about what CoreAudio and PortAudio actually
do, and a mock would only restate the assumption. It asserts that the probe
leaves an open stream playing, that a re-scan invalidates one, that PortAudio
agrees with the probe after a re-scan, and that the probe is cheap enough to run
per utterance. Those skip off macOS.

Verified end to end by switching the system default output under a live
`PlaybackQueue` and confirming it followed, across Bluetooth, the internal
speakers, and a virtual device.

## Note for review

The working tree has unrelated in-flight work — `banner.py`, `journal.py`, and
the `depth` property on `PlaybackQueue` — that is deliberately **not** in this
branch. The README here documents only what this branch contains, so its
test-coverage paragraph will want the journal added back when that work lands.
